### PR TITLE
Scope assignments to active

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -2,6 +2,13 @@ class Assignment < ApplicationRecord
   belongs_to :team
   belongs_to :person
 
+  scope :active, -> {
+      where(
+          "? between effective_date and coalesce(completion_date, ?)",
+          Date.today,
+          20_000.years.from_now
+      )
+    }
 
   def self.active_assignment_for_person person
     self.where("person_id=? and ? between effective_date and coalesce(completion_date, ?)", person.id, Date.today, 20_000.years.from_now)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -3,6 +3,6 @@ class Person < ApplicationRecord
   has_many :teams, through: :assignments
 
   def active_assignments
-    Assignment.active_assignment_for_person self
+    assignments.active
   end
 end

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -2,7 +2,7 @@
 
 <h3>Active Assignments</h3>
 <ul class="current-team-assignments">
-  <% Assignment.active_assignment_for_person(@person).each do |assignment| %>
+  <% @person.active_assignments.each do |assignment| %>
     <li class="assignment">
       <h4>Team: <%= assignment.team.name %></h4>
       Effective: <%= assignment.effective_date %><br>

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -9,9 +9,23 @@ class PersonTest < ActiveSupport::TestCase
   end
 
   test "#active_assignments" do
-    person = build(:person)
-    Assignment.stub :active_assignment_for_person, [:assignments] do
-      assert_equal [:assignments], person.active_assignments
-    end
+    person = create(:person)
+
+    active_assignment = create(
+        :assignment,
+        person: person,
+        team: create(:team),
+        effective_date: 1.day.ago,
+    )
+
+    inactive_assignment = create(
+        :assignment,
+        person: person,
+        team: create(:team),
+        effective_date: 1.day.from_now,
+    )
+
+    assert_includes person.active_assignments, active_assignment
+    refute_includes person.active_assignments, inactive_assignment
   end
 end


### PR DESCRIPTION
This is what I was thinking about

Scope active in Assignments, that way we can scope both people and teams
Person can use the scope in `active_assignments`